### PR TITLE
MRI: {Rect,Color,Tone}#initialize_copy instead of #clone

### DIFF
--- a/binding-mri/binding-util.h
+++ b/binding-mri/binding-util.h
@@ -195,17 +195,6 @@ rb_bool_new(bool value)
 		return objectLoad<Typ>(argc, argv, self, Typ##Type); \
 	}
 
-#define CLONE_FUNC(Klass) \
-	static mrb_value \
-	Klass##Clone(mrb_state *mrb, mrb_value self) \
-	{ \
-		Klass *k = getPrivateData<Klass>(mrb, self); \
-		mrb_value dupObj = mrb_obj_clone(mrb, self); \
-		Klass *dupK = new Klass(*k); \
-		setPrivateData(mrb, dupObj, dupK, Klass##Type); \
-		return dupObj; \
-	}
-
 #define CLONE_FUN(Klass) \
 	RB_METHOD(Klass##Clone) \
 	{ \
@@ -215,6 +204,18 @@ rb_bool_new(bool value)
 		Klass *dupK = new Klass(*k); \
 		setPrivateData(dupObj, dupK, Klass##Type); \
 		return dupObj; \
+	}
+
+#define INITCOPY_FUN(Klass) \
+	RB_METHOD(Klass##InitCopy) \
+	{ \
+		VALUE original; \
+		rb_get_args(argc, argv, "o", &original); \
+		if (!OBJ_INIT_COPY(self, original)) \
+			return self; \
+		Klass *k = getPrivateData<Klass>(original); \
+		setPrivateData(self, new Klass(*k), Klass##Type); \
+		return self; \
 	}
 
 /* If we're not binding a disposable class,

--- a/binding-mri/etc-binding.cpp
+++ b/binding-mri/etc-binding.cpp
@@ -148,9 +148,9 @@ MARSH_LOAD_FUN(Color)
 MARSH_LOAD_FUN(Tone)
 MARSH_LOAD_FUN(Rect)
 
-CLONE_FUN(Tone)
-CLONE_FUN(Color)
-CLONE_FUN(Rect)
+INITCOPY_FUN(Tone)
+INITCOPY_FUN(Color)
+INITCOPY_FUN(Rect)
 
 #define INIT_BIND(Klass) \
 { \
@@ -159,8 +159,8 @@ CLONE_FUN(Rect)
 	rb_define_class_method(klass, "_load", Klass##Load); \
 	serializableBindingInit<Klass>(klass); \
 	_rb_define_method(klass, "initialize", Klass##Initialize); \
+	_rb_define_method(klass, "initialize_copy", Klass##InitCopy); \
 	_rb_define_method(klass, "set", Klass##Set); \
-	_rb_define_method(klass, "clone", Klass##Clone); \
 	_rb_define_method(klass, "==", Klass##Equal); \
 	_rb_define_method(klass, "to_s", Klass##Stringify); \
 	_rb_define_method(klass, "inspect", Klass##Stringify); \


### PR DESCRIPTION
- removed unused CLONE_FUNC
- #initialize_copy should be used instead of #clone. It's the general way to do it and the RGSS defines it, too

Or was there a reason for directly defining #cloneinstead?

(Your code is weird. :3 Well, the RGSS is too but not in that way. And I don't mean the coding style! Rather stuff like `setPrivateData`. Why are two objects used? One object and one ivar called PRIV_IV which holds the data pointer, even though you could just use one object for that.)
