### PR TITLE
MRI: rewrite script eval (was: Question about $0)

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -295,11 +295,20 @@ static void runRMXPScripts()
 		VALUE string = newStringUTF8(RSTRING_PTR(scriptDecoded),
 		                             RSTRING_LEN(scriptDecoded));
 
-		char fname[32];
-		int len = snprintf(fname, sizeof(fname), "Section%03ld", i);
+		VALUE fname;
+		if (shState->rtData().config.useScriptNames)
+		{
+			fname = rb_ary_entry(script, 1);
+		}
+		else
+		{
+			char buf[32];
+			int len = snprintf(buf, sizeof(buf), "Section%03ld", i);
+			fname = newStringUTF8(buf, len);
+		}
 
 		int state;
-		evalString(string, newStringUTF8(fname, len), &state);
+		evalString(string, fname, &state);
 		if (state)
 			break;
 	}

--- a/mkxp.conf.sample
+++ b/mkxp.conf.sample
@@ -113,3 +113,9 @@
 # RTP=/path/to/rtp1
 # RTP=/path/to/rtp2.zip
 # RTP=/path/to/game.rgssad
+
+
+# Use the script's name as filename in warnings and error messages
+# (default: disabled)
+#
+# useScriptNames=false

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -49,7 +49,8 @@ Config::Config()
       gameFolder("."),
       anyAltToggleFS(false),
       allowSymlinks(false),
-      pathCache(true)
+      pathCache(true),
+      useScriptNames(false)
 {}
 
 void Config::read(int argc, char *argv[])
@@ -72,7 +73,8 @@ void Config::read(int argc, char *argv[])
 	PO_DESC(allowSymlinks, bool) \
 	PO_DESC(iconPath, std::string) \
 	PO_DESC(customScript, std::string) \
-	PO_DESC(pathCache, bool)
+	PO_DESC(pathCache, bool) \
+	PO_DESC(useScriptNames, bool)
 
 // Not gonna take your shit boost
 #define GUARD_ALL( exp ) try { exp } catch(...) {}

--- a/src/config.h
+++ b/src/config.h
@@ -51,6 +51,8 @@ struct Config
 
 	std::string iconPath;
 
+	bool useScriptNames;
+
 	std::string customScript;
 	std::vector<std::string> rtps;
 


### PR DESCRIPTION
Maybe there is a reason for setting `$0`. Could you tell me? I can only speculate:

It's far easier and more intuitive than this which doesn't work with mkxp:

``` ruby
$RGSS_SCRIPTS[__FILE__[/Section(\d+)/, 1].to_i][0]  # RGSS1 (and 2?)
```

So if that's a mkxp-specific extension, then it should be mentioned in the README.
