### PR TITLE
use `rb_funcall2` instead of `rb_funcallv`

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -212,7 +212,7 @@ RB_METHOD(_kernelCaller)
 
 	/* RMXP does this, not sure if specific or 1.8 related */
 	VALUE args[] = { rb_str_new_cstr(":in `<main>'"), rb_str_new_cstr("") };
-	rb_funcallv(rb_ary_entry(trace, len-1), rb_intern("gsub!"), 2, args);
+	rb_funcall2(rb_ary_entry(trace, len-1), rb_intern("gsub!"), 2, args);
 
 	return trace;
 }


### PR DESCRIPTION
In 2.1 `rb_funcall2`  was renamed to `rb_funcallv` and
a macro for backward compatibility was added.
