### PR TITLE
OS X pathCache bugfix/compatibility + small i18n fix

### DIFF
--- a/mkxp.conf.sample
+++ b/mkxp.conf.sample
@@ -163,3 +163,6 @@
 # Activate "reverb" effect for midi playback
 #
 # midi.reverb=false
+
+# Specify character encoding of Game.ini
+# iniCodec=UTF-8

--- a/mkxp.pro
+++ b/mkxp.pro
@@ -8,10 +8,14 @@ INCLUDEPATH += . src
 
 CONFIG(release, debug|release): DEFINES += NDEBUG
 
-CONFIG += MIDI
+CONFIG += MIDI INI_CODEC
 
 DISABLE_MIDI {
 	CONFIG -= MIDI
+}
+
+DISABLE_INI_CODEC {
+	CONFIG -= INI_CODEC
 }
 
 isEmpty(BINDING) {
@@ -77,8 +81,9 @@ contains(RGSS_VER, 3) {
 
 unix {
 	CONFIG += link_pkgconfig
-	PKGCONFIG += sigc++-2.0 pixman-1 zlib physfs \
-	             sdl2 SDL2_image SDL2_ttf SDL_sound openal
+	PKGCONFIG += sigc++-2.0 pixman-1 physfs \
+		     sdl2 SDL2_image SDL2_ttf SDL_sound
+	LIBS += -lz
 
 	RGSS2 {
 		PKGCONFIG += vorbisfile
@@ -110,6 +115,17 @@ unix {
 	}
 
 	LIBS += -lboost_program_options$$BOOST_LIB_SUFFIX
+}
+
+unix:!macx {
+	PKGCONFIG += openal
+}
+
+macx {
+	CONFIG -= app_bundle
+	QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
+	INCLUDEPATH += /System/Library/Frameworks/OpenAL.framework/Headers
+	LIBS += -liconv -framework OpenAL
 }
 
 # Input
@@ -246,6 +262,13 @@ MIDI {
 	src/midisource.cpp
 
 	DEFINES += MIDI
+}
+
+INI_CODEC {
+	DEFINES += INI_CODEC
+	win32 {
+		LIBS += -liconv
+	}
 }
 
 defineReplace(xxdOutput) {

--- a/src/config.h
+++ b/src/config.h
@@ -66,6 +66,8 @@ struct Config
 	} midi;
 
 	bool useScriptNames;
+    
+    std::string iniCodec;
 
 	std::string customScript;
 	std::vector<std::string> rtps;

--- a/src/gl-fun.h
+++ b/src/gl-fun.h
@@ -59,7 +59,7 @@ typedef void (APIENTRYP PFNGLACTIVETEXTUREPROC) (GLenum texture);
 typedef void (APIENTRY * _GLDEBUGPROC) (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void *userParam);
 typedef void (APIENTRYP _PFNGLDEBUGMESSAGECALLBACKPROC) (_GLDEBUGPROC callback, const void *userParam);
 
-#ifdef GLES2_HEADER
+#if defined GLES2_HEADER || defined __APPLE__
 #define GL_NUM_EXTENSIONS 0x821D
 
 /* Buffer object */


### PR DESCRIPTION
This mainly fixes the UTF-8 NFC/NFD pathCache bug on OS X by converting the filenames returned by PhysFS from NFD to NFC. It also includes some changes to gl-fun.h and mkxp.pro that make compiling mkxp on OS X easier and less error-prone. The cmake files aren't modified at all, since I really don't know what I'm doing there.

I've also added a small configuration option called iniCodec which will allow the user to specify the character encoding of the Game.ini file. While RGSS uses UTF-8 almost everwhere, Game.ini unfortunately remains Widnows-codepage specific. Like the UTF-8 fix above, it converts the text via iconv. This creates an extra dependency on Windows, so it can be disabled via DISABLE_INI_CODEC with qmake.
