### PR TITLE
MRI: use RB_TYPE_P() instead of rb_type()

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -223,7 +223,7 @@ RB_METHOD(_kernelCaller)
 
 	VALUE trace = rb_funcall2(rb_mKernel, rb_intern("_mkxp_kernel_caller_alias"), 0, 0);
 
-	if (rb_type(trace) != RUBY_T_ARRAY)
+	if (!RB_TYPE_P(trace, RUBY_T_ARRAY))
 		return trace;
 
 	long len = RARRAY_LEN(trace);
@@ -307,7 +307,7 @@ static void runRMXPScripts()
 
 	VALUE scriptArray = kernelLoadDataInt(scriptPack.c_str());
 
-	if (rb_type(scriptArray) != RUBY_T_ARRAY)
+	if (!RB_TYPE_P(scriptArray, RUBY_T_ARRAY))
 	{
 		showMsg("Failed to read script data");
 		return;
@@ -324,7 +324,7 @@ static void runRMXPScripts()
 	{
 		VALUE script = rb_ary_entry(scriptArray, i);
 
-		if (rb_type(script) != RUBY_T_ARRAY)
+		if (!RB_TYPE_P(script, RUBY_T_ARRAY))
 			continue;
 
 		VALUE scriptName   = rb_ary_entry(script, 1);

--- a/binding-mri/binding-util.cpp
+++ b/binding-mri/binding-util.cpp
@@ -161,7 +161,7 @@ rb_get_args(int argc, VALUE *argv, const char *format, ...)
 			VALUE *str = va_arg(ap, VALUE*);
 			VALUE tmp = *arg;
 
-			if (!(rb_type(tmp) == RUBY_T_STRING))
+			if (!RB_TYPE_P(tmp, RUBY_T_STRING))
 				rb_raise(rb_eTypeError, "Argument %d: Expected string", argI);
 
 			*str = tmp;
@@ -180,7 +180,7 @@ rb_get_args(int argc, VALUE *argv, const char *format, ...)
 
 			VALUE tmp = *arg;
 
-			if (!(rb_type(tmp) == RUBY_T_STRING))
+			if (!RB_TYPE_P(tmp, RUBY_T_STRING))
 				rb_raise(rb_eTypeError, "Argument %d: Expected string", argI);
 
 			*s = RSTRING_PTR(tmp);
@@ -199,7 +199,7 @@ rb_get_args(int argc, VALUE *argv, const char *format, ...)
 
 			VALUE tmp = *arg++;
 
-			if (!(rb_type(tmp) == RUBY_T_STRING))
+			if (!RB_TYPE_P(tmp, RUBY_T_STRING))
 				rb_raise(rb_eTypeError, "Argument %d: Expected string", argI);
 
 			*s = RSTRING_PTR(tmp);

--- a/binding-mri/bitmap-binding.cpp
+++ b/binding-mri/bitmap-binding.cpp
@@ -258,7 +258,7 @@ RB_METHOD(bitmapDrawText)
 			VALUE strObj;
 			rb_get_args(argc, argv, "oo|i", &rectObj, &strObj, &align RB_ARG_END);
 
-			if (rb_type(strObj) != RUBY_T_STRING)
+			if (!RB_TYPE_P(strObj, RUBY_T_STRING))
 				strObj = rb_funcallv(strObj, rb_intern("to_s"), 0, 0);
 
 			str = RSTRING_PTR(strObj);
@@ -281,7 +281,7 @@ RB_METHOD(bitmapDrawText)
 			VALUE strObj;
 			rb_get_args(argc, argv, "iiiio|i", &x, &y, &width, &height, &strObj, &align RB_ARG_END);
 
-			if (rb_type(strObj) != RUBY_T_STRING)
+			if (!RB_TYPE_P(strObj, RUBY_T_STRING))
 				strObj = rb_funcallv(strObj, rb_intern("to_s"), 0, 0);
 
 			str = RSTRING_PTR(strObj);
@@ -308,7 +308,7 @@ RB_METHOD(bitmapTextSize)
 		VALUE strObj;
 		rb_get_args(argc, argv, "o", &strObj RB_ARG_END);
 
-		if (rb_type(strObj) != RUBY_T_STRING)
+		if (!RB_TYPE_P(strObj, RUBY_T_STRING))
 			strObj = rb_funcallv(strObj, rb_intern("to_s"), 0, 0);
 
 		str = RSTRING_PTR(strObj);

--- a/binding-mri/filesystem-binding.cpp
+++ b/binding-mri/filesystem-binding.cpp
@@ -159,7 +159,7 @@ RB_METHOD(kernelSaveData)
 
 static VALUE stringForceUTF8(VALUE arg)
 {
-	if (rb_type(arg) == RUBY_T_STRING && ENCODING_IS_ASCII8BIT(arg))
+	if (RB_TYPE_P(arg, RUBY_T_STRING) && ENCODING_IS_ASCII8BIT(arg))
 		rb_enc_associate_index(arg, rb_utf8_encindex());
 
 	return arg;

--- a/binding-mri/font-binding.cpp
+++ b/binding-mri/font-binding.cpp
@@ -38,7 +38,7 @@ RB_METHOD(fontDoesExist)
 
 	rb_get_args(argc, argv, "o", &nameObj RB_ARG_END);
 
-	if (rb_type(nameObj) == RUBY_T_STRING)
+	if (RB_TYPE_P(nameObj, RUBY_T_STRING))
 		name = rb_string_value_cstr(&nameObj);
 
 	return rb_bool_new(Font::doesExist(name));
@@ -116,24 +116,23 @@ fontSetNameHelper(VALUE self, int argc, VALUE *argv,
 	rb_check_argc(argc, 1);
 
 	VALUE arg = argv[0];
-	int type = rb_type(arg);
 
 	// Fixme: in RGSS3, specifying "" (and only that) as font name results in
 	// no text being drawn (everything else is substituted with Arial I think)
 	strncpy(outBuf, "", outLen);
 
-	if (type == RUBY_T_STRING)
+	if (RB_TYPE_P(arg, RUBY_T_STRING))
 	{
 		strncpy(outBuf, RSTRING_PTR(arg), outLen);
 	}
-	else if (type == RUBY_T_ARRAY)
+	else if (RB_TYPE_P(arg, RUBY_T_ARRAY))
 	{
 		for (long i = 0; i < RARRAY_LEN(arg); ++i)
 		{
 			VALUE str = rb_ary_entry(arg, i);
 
 			/* Non-string objects are tolerated (ignored) */
-			if (rb_type(str) != RUBY_T_STRING)
+			if (!RB_TYPE_P(str, RUBY_T_STRING))
 				continue;
 
 			const char *family = RSTRING_PTR(str);


### PR DESCRIPTION
Nothing important, but I'm currently fixing some issues with `rb_get_args` and I've noticed that almost everywhere `RB_TYPE_P` (which selects the right comparison) can be used instead of `rb_type` (which most probably doesn't).
