### PR TITLE
add RGSS_VERSION (RGSS3)

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -113,6 +113,8 @@ static void mriBindingInit()
 
 		_rb_define_module_function(rb_mKernel, "msgbox",    mriPrint);
 		_rb_define_module_function(rb_mKernel, "msgbox_p",  mriP);
+
+		rb_define_global_const("RGSS_VERSION", rb_str_new_cstr("3.0.0"));
 	}
 	else
 	{


### PR DESCRIPTION
Even though 3.0.1 is the current version, 3.0.0 is used, because mkxp doesn't
implement the changes like not raising a TypeError for 'Color.new == nil' yet.
3.0.1 (finally) returns false. Other changes don't affect mkxp (I think).

See http://tkool.jp/support/download/rpgvxace/rpgvxace_update (Japanese).

---

The comparison change and maybe adding `RGSS_VERSION` for `rgssVer == 1` and `rgssVer == 2` requires some discussion.

I think mkxp should implement 3.0.1's behavior for `rgssVer == 3` as its usage is higher than 3.0.0, because the international VX Ace defaults to RGSS301.dll since its release.
