### PR TITLE
fix Bitmap's object to string conversion

### DIFF
--- a/binding-mri/bitmap-binding.cpp
+++ b/binding-mri/bitmap-binding.cpp
@@ -29,6 +29,12 @@
 
 DEF_TYPE(Bitmap);
 
+static const char *objAsStringPtr(VALUE obj)
+{
+	VALUE str = rb_obj_as_string(obj);
+	return RSTRING_PTR(str);
+}
+
 void bitmapInitProps(Bitmap *b, VALUE self)
 {
 	/* Wrap properties */
@@ -258,10 +264,7 @@ RB_METHOD(bitmapDrawText)
 			VALUE strObj;
 			rb_get_args(argc, argv, "oo|i", &rectObj, &strObj, &align RB_ARG_END);
 
-			if (!RB_TYPE_P(strObj, RUBY_T_STRING))
-				strObj = rb_funcallv(strObj, rb_intern("to_s"), 0, 0);
-
-			str = RSTRING_PTR(strObj);
+			str = objAsStringPtr(strObj);
 		}
 		else
 		{
@@ -281,10 +284,7 @@ RB_METHOD(bitmapDrawText)
 			VALUE strObj;
 			rb_get_args(argc, argv, "iiiio|i", &x, &y, &width, &height, &strObj, &align RB_ARG_END);
 
-			if (!RB_TYPE_P(strObj, RUBY_T_STRING))
-				strObj = rb_funcallv(strObj, rb_intern("to_s"), 0, 0);
-
-			str = RSTRING_PTR(strObj);
+			str = objAsStringPtr(strObj);
 		}
 		else
 		{
@@ -308,10 +308,7 @@ RB_METHOD(bitmapTextSize)
 		VALUE strObj;
 		rb_get_args(argc, argv, "o", &strObj RB_ARG_END);
 
-		if (!RB_TYPE_P(strObj, RUBY_T_STRING))
-			strObj = rb_funcallv(strObj, rb_intern("to_s"), 0, 0);
-
-		str = RSTRING_PTR(strObj);
+		str = objAsStringPtr(strObj);
 	}
 	else
 	{


### PR DESCRIPTION
Calling #to_s might not return a string (it should though).

The RGSS also calls `rb_obj_as_string`:

``` ruby
class A
  B = 'Test'
  def to_s; B; end
end
s = Sprite.new
s.bitmap = Bitmap.new(Graphics.width, Graphics.height)
p A::B.tainted?  # => false
a = A.new
a.taint  # a is tainted, not A::B!
s.bitmap.draw_text(s.bitmap.rect, a)   # rb_obj_as_string() taints the return value of A#to_s (A::B)
p A::B.tainted?  # => true
rgss_stop
```

Don't worry about tainting, I just wanted to prove it (for some reason). More importantly is that RGSS classes don't check if the string contains `'\0'`. For example, drawing `"Te\0st"` doesn't raise an error like it should (see “poison null byte”) and only draws `Te`. Should mkxp?
