### PR TITLE
Xbox controllers require JoyHat events to be tracked on windows

### DIFF
--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -38,7 +38,7 @@ uint8_t EventThread::keyStates[] = { false };
 
 EventThread::JoyState EventThread::joyState =
 {
-	{ 0 }, { false }
+	{ 0 }, { 0 }, { false }
 };
 
 EventThread::MouseState EventThread::mouseState =
@@ -274,8 +274,12 @@ void EventThread::process(RGSSThreadData &rtData)
 			joyState.buttons[event.jbutton.button] = false;
 			break;
 
+		case SDL_JOYHATMOTION :
+			joyState.hats[event.jhat.hat] = event.jhat.value;
+			break;
+
 		case SDL_JOYAXISMOTION :
-			joyState.axis[event.jaxis.axis] = event.jaxis.value;
+			joyState.axes[event.jaxis.axis] = event.jaxis.value;
 			break;
 
 		case SDL_JOYDEVICEADDED :

--- a/src/eventthread.h
+++ b/src/eventthread.h
@@ -46,7 +46,8 @@ public:
 
 	struct JoyState
 	{
-		int axis[256];
+		int axes[256];
+		uint8_t hats[256];
 		bool buttons[256];
 	};
 

--- a/src/keybindings.cpp
+++ b/src/keybindings.cpp
@@ -129,6 +129,20 @@ static void addAxisBinding(BDescVec &d, uint8_t axis, AxisDir dir, Input::Button
 	d.push_back(desc);
 }
 
+static void addHatBinding(BDescVec &d, uint8_t hat, uint8_t pos, Input::ButtonCode target)
+{
+	SourceDesc src;
+	src.type = JHat;
+	src.d.jh.hat = hat;
+	src.d.jh.pos = pos;
+
+	BindingDesc desc;
+	desc.src = src;
+	desc.target = target;
+
+	d.push_back(desc);
+}
+
 BDescVec genDefaultBindings(const Config &conf)
 {
 	BDescVec d;
@@ -150,11 +164,16 @@ BDescVec genDefaultBindings(const Config &conf)
 	addAxisBinding(d, 0, Positive, Input::Right);
 	addAxisBinding(d, 1, Negative, Input::Up   );
 	addAxisBinding(d, 1, Positive, Input::Down );
+	
+	addHatBinding(d, 0, SDL_HAT_LEFT,  Input::Left );
+	addHatBinding(d, 0, SDL_HAT_RIGHT, Input::Right);
+	addHatBinding(d, 0, SDL_HAT_UP,    Input::Up   );
+	addHatBinding(d, 0, SDL_HAT_DOWN,  Input::Down );
 
 	return d;
 }
 
-#define FORMAT_VER 1
+#define FORMAT_VER 2
 
 struct Header
 {
@@ -247,6 +266,10 @@ static bool verifyDesc(const BindingDesc &desc)
 		return src.d.scan < SDL_NUM_SCANCODES;
 	case JButton:
 		return true;
+	case JHat:
+		/* Only accept single directional binds */
+		return src.d.jh.pos == SDL_HAT_LEFT || src.d.jh.pos == SDL_HAT_RIGHT ||
+		       src.d.jh.pos == SDL_HAT_UP   || src.d.jh.pos == SDL_HAT_DOWN;
 	case JAxis:
 		return src.d.ja.dir == Negative || src.d.ja.dir == Positive;
 	default:

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -25,6 +25,7 @@
 #include "input.h"
 
 #include <SDL_scancode.h>
+#include <SDL_joystick.h>
 #include <stdint.h>
 #include <assert.h>
 #include <vector>
@@ -40,7 +41,8 @@ enum SourceType
 	Invalid,
 	Key,
 	JButton,
-	JAxis
+	JAxis,
+	JHat
 };
 
 struct SourceDesc
@@ -60,6 +62,13 @@ struct SourceDesc
 			/* Joystick axis direction */
 			AxisDir dir;
 		} ja;
+		struct
+		{
+			/* Joystick axis index */
+			uint8_t hat;
+			/* Joystick axis direction */
+			uint8_t pos;
+		} jh;
 	} d;
 
 	bool operator==(const SourceDesc &o) const
@@ -77,6 +86,8 @@ struct SourceDesc
 			return d.jb == o.d.jb;
 		case JAxis:
 			return (d.ja.axis == o.d.ja.axis) && (d.ja.dir == o.d.ja.dir);
+		case JHat:
+			return (d.jh.hat == o.d.jh.hat) && (d.jh.pos == o.d.jh.pos);
 		default:
 			assert(!"unreachable");
 			return false;

--- a/src/settingsmenu.cpp
+++ b/src/settingsmenu.cpp
@@ -81,6 +81,7 @@ static elementsN(vButtons);
 std::string sourceDescString(const SourceDesc &src)
 {
 	char buf[128];
+	char pos;
 
 	switch (src.type)
 	{
@@ -102,6 +103,32 @@ std::string sourceDescString(const SourceDesc &src)
 	}
 	case JButton:
 		snprintf(buf, sizeof(buf), "JS %d", src.d.jb);
+		return buf;
+
+	case JHat:
+		switch(src.d.jh.pos)
+		{
+		case SDL_HAT_UP:
+			pos = 'U';
+			break;
+
+		case SDL_HAT_DOWN:
+			pos = 'D';
+			break;
+
+		case SDL_HAT_LEFT:
+			pos = 'L';
+			break;
+
+		case SDL_HAT_RIGHT:
+			pos = 'R';
+			break;
+
+		default:
+			pos = '-';
+		}
+		snprintf(buf, sizeof(buf), "Hat %d:%c",
+		         src.d.jh.hat, pos);
 		return buf;
 
 	case JAxis:
@@ -616,6 +643,21 @@ struct SettingsMenuPrivate
 			desc.d.jb = event.jbutton.button;
 			break;
 
+		case SDL_JOYHATMOTION:
+		{
+			int v = event.jhat.value;
+
+			/* Only register if single directional input */
+			if (v != SDL_HAT_LEFT && v != SDL_HAT_RIGHT &&
+			    v != SDL_HAT_UP   && v != SDL_HAT_DOWN)
+				return true;
+
+			desc.type = JHat;
+			desc.d.jh.hat = event.jhat.hat;
+			desc.d.jh.pos = v;
+			break;
+		}
+
 		case SDL_JOYAXISMOTION:
 		{
 			int v = event.jaxis.value;
@@ -1008,6 +1050,7 @@ bool SettingsMenu::onEvent(const SDL_Event &event)
 
 	case SDL_JOYBUTTONDOWN :
 	case SDL_JOYBUTTONUP :
+	case SDL_JOYHATMOTION :
 	case SDL_JOYAXISMOTION :
 		if (!p->hasFocus)
 			return false;
@@ -1084,6 +1127,7 @@ bool SettingsMenu::onEvent(const SDL_Event &event)
 		}
 
 	case SDL_JOYBUTTONDOWN:
+	case SDL_JOYHATMOTION:
 	case SDL_JOYAXISMOTION:
 		if (p->state != AwaitingInput)
 			return true;


### PR DESCRIPTION
Edit: I've decided to make this issue about the JoyHat event thing on windows only, if I think of a good way to leverage SDL_GameController without removing features I'll open another issue/pull request.

Controllers are one of the things that are a huge mess, especially across multiple platforms, so using SDL_joystick on its own is often not enough to get consistent behaviour across different gamepads and  operating systems.

This is why SDL_GameController is a thing, it works on top of SDL_joystick. It takes community sourced mappings to map all joystick buttons to a generic controller that looks like an xbox gamepad, if an application is launched via Steam, Steam will also automatically pass controller bindings that have been previously setup in big picture mode for the connected gamepads.

I haven't looked into how much code would have to be changed to make this work, but it seems manageable and I will probably get started on a patch to implement this soon, I think the benefits definitely would outweigh the amount of work it is to port it over from pure SDL_joystick to SDL_GameController.

The main motivation for this is, that MKXP already doesn't handle all controller buttons on all operating systems, and there's also differences in the button enumeration across different drivers, Xbox controllers for example will not let you assign the dpad on Windows because it's mapped to a weird thing that's neither a button nor an axis.
