### PR TITLE
Make it easier to change the bundled font.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ option(WORKDIR_CURRENT "Keep current directory on startup" OFF)
 option(FORCE32 "Force 32bit compile on 64bit OS" OFF)
 set(BINDING "MRI" CACHE STRING "The Binding Type (MRI, MRUBY, NULL)")
 set(EXTERNAL_LIB_PATH "" CACHE PATH "External precompiled lib prefix")
+set(BUNDLED_FONT "liberation" CACHE STRING "Bundled font name; file must exist in assets")
+set_property(CACHE BUNDLED_FONT PROPERTY ADVANCED ON)
 
 ## Misc setup ##
 
@@ -234,7 +236,7 @@ set(EMBEDDED_INPUT
 	shader/blurH.vert
 	shader/blurV.vert
 	shader/simpleMatrix.vert
-	assets/liberation.ttf
+	assets/${BUNDLED_FONT}.ttf
 	assets/icon.png
 )
 
@@ -402,6 +404,7 @@ add_executable(${PROJECT_NAME} MACOSX_BUNDLE
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
 	${DEFINES}
+	BUNDLED_FONT=${BUNDLED_FONT}
 )
 target_include_directories(${PROJECT_NAME} PRIVATE
 	src

--- a/mkxp.pro
+++ b/mkxp.pro
@@ -222,6 +222,8 @@ defineReplace(xxdOutput) {
 	return($$basename(1).xxd)
 }
 
+DEFINES += BUNDLED_FONT=liberation
+
 # xxd
 xxd.output_function = xxdOutput
 xxd.commands = xxd -i ${QMAKE_FILE_NAME} > ${QMAKE_FILE_OUT}

--- a/src/bundledfont.cpp
+++ b/src/bundledfont.cpp
@@ -1,1 +1,4 @@
-#include "liberation.ttf.xxd"
+#define BUNDLED_FONT_NAME BUNDLED_FONT.ttf.xxd
+#define STRINGIFY(x) #x
+#define INCLUDE_FILE(x) STRINGIFY(x)
+#include INCLUDE_FILE(BUNDLED_FONT_NAME)

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -33,16 +33,14 @@
 
 #include <SDL_ttf.h>
 
-#define BUNDLED_FONT liberation
-
-#define BUNDLED_FONT_DECL(FONT) \
-	extern unsigned char assets_##FONT##_ttf[]; \
-	extern unsigned int assets_##FONT##_ttf_len;
-
-BUNDLED_FONT_DECL(liberation)
-
 #define BUNDLED_FONT_D(f) assets_## f ##_ttf
 #define BUNDLED_FONT_L(f) assets_## f ##_ttf_len
+
+#define BUNDLED_FONT_DECL(FONT) \
+	extern unsigned char BUNDLED_FONT_D(FONT)[]; \
+	extern unsigned int BUNDLED_FONT_L(FONT);
+
+BUNDLED_FONT_DECL(BUNDLED_FONT)
 
 // Go fuck yourself CPP
 #define BNDL_F_D(f) BUNDLED_FONT_D(f)


### PR DESCRIPTION
This makes it easier to play CJK games, since the embedded font must have the glyphs necessary to display the game text.  This however does not change the default, so liberation is still used in the default setting.  Because needing to have the file under `assets/` is unusual, it's listed as an advanced configuration option.

The qmake portion is untested, but should hopefully not break the build.

See also #135 