### PR TITLE
Add MRI 1.8 Support

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -32,7 +32,9 @@
 #include "boost-hash.h"
 
 #include <ruby.h>
+#if RUBY_API_VERSION_MAJOR > 1
 #include <ruby/encoding.h>
+#endif
 
 #include <assert.h>
 #include <string>
@@ -195,7 +197,7 @@ RB_METHOD(mriP)
 RB_METHOD(mkxpDataDirectory)
 {
 	RB_UNUSED_PARAM;
-	
+
 	const std::string &path = shState->config().customDataPath;
 	const char *s = path.empty() ? "." : path.c_str();
 
@@ -571,9 +573,15 @@ static void mriBindingExecute()
 	 * stdio streams on some platforms (eg. Windows) */
 	int argc = 0;
 	char **argv = 0;
-	ruby_sysinit(&argc, &argv);
 
+#if RUBY_API_VERSION_MAJOR == 1
+	ruby_init();
+	//ruby_options(argc, argv);
+#else
+	ruby_sysinit(&argc, &argv);
 	ruby_setup();
+#endif
+
 	rb_enc_set_default_external(rb_enc_from_encoding(rb_utf8_encoding()));
 
 	Config &conf = shState->rtData().config;

--- a/binding-mri/binding-util.h
+++ b/binding-mri/binding-util.h
@@ -23,8 +23,123 @@
 #define BINDING_UTIL_H
 
 #include <ruby.h>
+#include <ruby/version.h>
 
 #include "exception.h"
+
+// Ruby 1.8 and Ruby 2.x use different version macros
+#ifndef RUBY_API_VERSION_MAJOR
+#define RUBY_API_VERSION_MAJOR RUBY_VERSION_MAJOR
+#endif
+
+#if RUBY_API_VERSION_MAJOR == 1
+// Functions and macros providing Ruby 1.8 compatibililty
+#define FLONUM_P(x) 0
+
+#define RB_FLOAT_TYPE_P(obj) (FLONUM_P(obj) || (!SPECIAL_CONST_P(obj) && BUILTIN_TYPE(obj) == T_FLOAT))
+
+#define RB_TYPE_P(obj, type) ( \
+	((type) == T_FIXNUM) ? FIXNUM_P(obj) : \
+	((type) == T_TRUE) ? ((obj) == Qtrue) : \
+	((type) == T_FALSE) ? ((obj) == Qfalse) : \
+	((type) == T_NIL) ? ((obj) == Qnil) : \
+	((type) == T_UNDEF) ? ((obj) == Qundef) : \
+	((type) == T_SYMBOL) ? SYMBOL_P(obj) : \
+        ((type) == T_FLOAT) ? RB_FLOAT_TYPE_P(obj) : \
+	(!SPECIAL_CONST_P(obj) && BUILTIN_TYPE(obj) == (type)))
+
+#define RUBY_T_ARRAY T_ARRAY
+#define RUBY_T_STRING T_STRING
+#define RUBY_T_FLOAT T_FLOAT
+#define RUBY_T_FIXNUM T_FIXNUM
+#define RUBY_T_TRUE T_TRUE
+#define RUBY_T_FALSE T_FALSE
+#define RUBY_T_NIL T_NIL
+
+#define OBJ_INIT_COPY(obj, orig) \
+    ((obj) != (orig) && (rb_obj_init_copy((obj), (orig)), 1))
+
+#define rb_str_new_cstr rb_str_new2
+
+#define RUBY_DEFAULT_FREE ((RUBY_DATA_FUNC)-1)
+#define RUBY_NEVER_FREE   ((RUBY_DATA_FUNC)0)
+#define RUBY_TYPED_DEFAULT_FREE RUBY_DEFAULT_FREE
+#define RUBY_TYPED_NEVER_FREE   RUBY_NEVER_FREE
+
+#define PRIsVALUE "s"
+#define RB_OBJ_CLASSNAME(obj) rb_obj_classname(obj)
+#define RB_OBJ_STRING(obj) StringValueCStr(obj)
+
+#define RTYPEDDATA_DATA DATA_PTR
+
+#define RFLOAT_VALUE(d) RFLOAT(d)->value
+
+#define ENCODING_INLINE_MAX 127
+#define ENCODING_SHIFT (FL_USHIFT+10)
+#define ENCODING_MASK (((VALUE)ENCODING_INLINE_MAX)<<ENCODING_SHIFT) /* FL_USER10|FL_USER11|FL_USER12|FL_USER13|FL_USER14|FL_USER15|FL_USER16 */
+
+#define ENCODING_SET_INLINED(obj,i) do {\
+    RBASIC(obj)->flags &= ~ENCODING_MASK;\
+    RBASIC(obj)->flags |= (VALUE)(i) << ENCODING_SHIFT;\
+} while (0)
+#define ENCODING_SET(obj,i) rb_enc_set_index((obj), (i))
+
+#define ENCODING_GET_INLINED(obj) (int)((RBASIC(obj)->flags & ENCODING_MASK)>>ENCODING_SHIFT)
+#define ENCODING_GET(obj) \
+    (ENCODING_GET_INLINED(obj) != ENCODING_INLINE_MAX ? \
+     ENCODING_GET_INLINED(obj) : \
+     rb_enc_get_index(obj))
+
+#define ENCODING_IS_ASCII8BIT(obj) (ENCODING_GET_INLINED(obj) == 0)
+
+typedef struct {
+    const char *wrap_struct_name;
+    struct {
+	void (*dmark)(void*);
+	void (*dfree)(void*);
+	size_t (*dsize)(const void *);
+	void *reserved[2];
+    } function;
+    const char *parent;
+    void *data;
+    VALUE flags;
+} rb_data_type_t;
+
+VALUE rb_sprintf(const char* fmt, ...);
+
+VALUE rb_data_typed_object_alloc(VALUE klass, void *datap, const rb_data_type_t *);
+
+void *rb_check_typeddata(VALUE, const rb_data_type_t *);
+
+#define Check_TypedStruct(v,t) rb_check_typeddata((VALUE)(v),(t))
+
+NORETURN(void rb_error_arity(int, int, int));
+
+typedef void rb_encoding;
+
+VALUE rb_enc_str_new(const char*, long, rb_encoding*);
+
+rb_encoding *rb_utf8_encoding(void);
+
+void rb_enc_set_default_external(VALUE encoding);
+
+VALUE rb_enc_from_encoding(rb_encoding *enc);
+
+VALUE rb_str_catf(VALUE, const char*, ...);
+
+VALUE rb_errinfo(void);
+
+int rb_typeddata_is_kind_of(VALUE, const rb_data_type_t *);
+
+VALUE rb_file_open_str(VALUE, const char*);
+
+VALUE rb_enc_associate_index(VALUE, int);
+
+int rb_utf8_encindex(void);
+
+VALUE rb_hash_lookup2(VALUE, VALUE, VALUE);
+
+#endif
 
 enum RbException
 {
@@ -66,7 +181,6 @@ raiseRbExc(const Exception &exc);
 	extern rb_data_type_t Klass##Type
 
 /* 2.1 has added a new field (flags) to rb_data_type_t */
-#include <ruby/version.h>
 #if RUBY_API_VERSION_MINOR > 0
 /* TODO: can mkxp use RUBY_TYPED_FREE_IMMEDIATELY here? */
 #define DEF_TYPE_FLAGS 0


### PR DESCRIPTION
This allows compiling of rmxp against Ruby 1.8.7 (tested with p374).

To test that it works simply start a RPG Maker XP game. If you get "Win32Api not found" instead of "Syntax error" it works ;).

This is mostly implemented by providing wrapper functions and macros (mostly copy-pasted from ruby 2.4) in binding-util.h. 

Known issues:
 - Everything encoding related is no-op by now. Includes the UTF8-Marhsaller. Guess I need to use the iconv-module here. I know that ruby reworked the whole encoding code in Ruby 2 but my Ruby knowledge is almost zero so I'm a bit lost here :(
 - ruby_option (like ruby_sysinit) segfaults when called.
 - rb_check_typeddata not implemented
 - rb_typeddata_is_kind_of not implemented
 - rb_hash_lookup2 not implemented but this is only in a RGSS3 codepath, so not relevant
 - rb_str_catf not implemented (so no stacktrace printed in error case)
 - raiseDisposedAccess will never raise

That typed data stuff was a bit tricky to fake because Ruby 1.8 does not have this typed data struct. But is good enough to launch games. Though some sanity checks are missing (see issues above)

To The Moon (Windows version) with 2.4 MRI:
![screenshot_20170512_023350](https://cloud.githubusercontent.com/assets/1331889/25977362/7a2ca61e-36bb-11e7-96db-786f7854b737.png)

With 1.8 MRI:
![screenshot_20170512_023314](https://cloud.githubusercontent.com/assets/1331889/25977364/7a40b924-36bb-11e7-9221-e87105d4e977.png)

With 1.8 MRI and some WinApi emulation (Mouse cursor is stuck):
![screenshot_20170512_023212](https://cloud.githubusercontent.com/assets/1331889/25977363/7a3a9080-36bb-11e7-9942-47a9b7762b4b.png)




