### PR TITLE
Add macOS bundle completion scripts

### DIFF
--- a/patches/macos/CompleteBundle.cmake
+++ b/patches/macos/CompleteBundle.cmake
@@ -1,0 +1,71 @@
+#-- Need this for link line stuff?
+if(COMMAND cmake_policy)
+	cmake_policy(SET CMP0009 NEW)
+endif(COMMAND cmake_policy)
+
+# gp_item_default_embedded_path item default_embedded_path_var
+#
+# Return the path that others should refer to the item by when the item
+# is embedded inside a bundle.
+#
+# Override on a per-project basis by providing a project-specific
+# gp_item_default_embedded_path_override function.
+#
+function(gp_item_default_embedded_path_override item default_embedded_path_var)
+	#
+	# The assumption here is that all executables in the bundle will be
+	# in same-level-directories inside the bundle. The parent directory
+	# of an executable inside the bundle should be MacOS or a sibling of
+	# MacOS and all embedded paths returned from here will begin with
+	# "@loader_path/../" and will work from all executables in all
+	# such same-level-directories inside the bundle.
+	#
+
+	# By default, embed things right next to the main bundle executable:
+	#
+	set (install_name_prefix "@executable_path")
+	# -------------------------------------------------------------------
+	# If your application uses plugins then you should consider using the following
+	#  instead but will limit your deployment to OS X 10.4. There is also a patch
+	#  needed for CMake that as of Sept 30, 2008 has NOT been applied to CMake.
+	#  set (install_name_prefix "@loader_path")
+	
+	set(path "${install_name_prefix}/../../Contents/MacOS")
+
+	set(overridden 0)
+
+	# Embed .dylibs in the Libraries Directory
+	#
+	if(item MATCHES "\\.dylib$")
+		set(path "${install_name_prefix}/../Libraries")
+		set(overridden 1)
+	endif(item MATCHES "\\.dylib$")
+
+	# Embed .so files in the Plugins directory
+	#
+	if(item MATCHES "\\.so$")
+		set(path "${install_name_prefix}/../Plugins")
+		set(overridden 1)
+	endif(item MATCHES "\\.so$")
+	
+	# Embed frameworks in the embedded "Frameworks" directory (sibling of MacOS):
+	#
+	if(NOT overridden)
+		if(item MATCHES "[^/]+\\.framework/")
+			set(path "${install_name_prefix}/../Frameworks")
+			set(overridden 1)
+		endif(item MATCHES "[^/]+\\.framework/")
+	endif(NOT overridden)
+
+	set(${default_embedded_path_var} "${path}" PARENT_SCOPE)
+endfunction(gp_item_default_embedded_path_override)
+
+# -- Copy the App bundle to the installation location first
+EXECUTE_PROCESS(COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/patches/macos/CreateBundle.sh")
+
+# -- Run the BundleUtilities cmake code
+include(BundleUtilities)
+set(BU_CHMOD_BUNDLE_ITEMS ON)
+fixup_bundle("${CMAKE_CURRENT_SOURCE_DIR}/mkxp.app" "" "${CMAKE_CURRENT_SOURCE_DIR}")
+execute_process(COMMAND chmod 0700 "${CMAKE_CURRENT_SOURCE_DIR}/mkxp.app")
+execute_process(COMMAND sh -c "cp -rf ${CMAKE_CURRENT_SOURCE_DIR}/patches/macos/mkxp.conf ${CMAKE_CURRENT_SOURCE_DIR}/mkxp.app/Contents/Resources/mkxp.conf")

--- a/patches/macos/CreateBundle.sh
+++ b/patches/macos/CreateBundle.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+OSX_App="$pwd/mkxp.app"
+ContentsDir="$OSX_App/Contents"
+LibrariesDir="$OSX_App/Contents/Libraries"
+
+# create directories in the @target@.app bundle
+if [ ! -e $LibrariesDir ]
+	then
+	mkdir -p "$LibrariesDir"
+fi

--- a/patches/macos/mkxp.conf
+++ b/patches/macos/mkxp.conf
@@ -1,0 +1,298 @@
+# Lines starting with '#' are comments.
+#
+# About filesystem paths specified in this config:
+# The "gameFolder" path is resolved either relative
+# to the directory containing the mkxp executable
+# (the default behavior), or relative to the current
+# working directory (when compiled with 
+# -DWORKDIR_CURRENT). All other paths are resolved
+# relative to gameFolder and ignoring both RTPs and
+# encrypted archives.
+
+
+# Specify the RGSS version to run under.
+# Possible values are 0, 1, 2, 3. If set to 0,
+# mkxp will try to guess the required version
+# based on the game files found in gameFolder.
+# If this fails, the version defaults to 1.
+# (default: 0)
+#
+# rgssVersion=1
+
+
+# Create a debug context and log
+# OpenGL debug information to the console
+# (default: disabled)
+#
+# debugMode=false
+
+
+# Continuously print average FPS to console.
+# This setting does not affect the window title
+# FPS display toggled via F2
+# (default: disabled)
+#
+# printFPS=false
+
+
+# Game window is resizable
+# (default: disabled)
+#
+# winResizable=false
+
+
+# Start game in fullscreen (this can
+# always be toggled with Alt-Enter at runtime)
+# (default: disabled)
+#
+# fullscreen=false
+
+
+# Preserve game screen aspect ratio,
+# as opposed to stretch-to-fill
+# (default: enabled)
+#
+# fixedAspectRatio=true
+
+
+# Apply linear interpolation when game screen
+# is upscaled
+# (default: enabled)
+#
+# smoothScaling=true
+
+
+# Sync screen redraws to the monitor refresh rate
+# (default: disabled)
+#
+# vsync=false
+
+
+# Specify the window width on startup. If set to 0,
+# it will default to the default resolution width
+# specific to  the RGSS version (640 in RGSS1, 544
+# in RGSS2 or higher).
+# (default: 0)
+#
+# defScreenW=640
+
+
+# Specify the window height on startup. If set to 0,
+# it will default to the default resolution height
+# specific to the RGSS version (480 in RGSS1, 416
+# in RGSS2 or higher).
+# (default: 0)
+#
+# defScreenH=480
+
+
+# Enforce a static frame rate
+# (0 = disabled)
+#
+# fixedFramerate=0
+
+
+# Skip (don't draw) frames when behind
+# (default: enabled)
+#
+# frameSkip=true
+
+
+# Use a fixed framerate that is approx. equal to the
+# native screen refresh rate. This is different from
+# "fixedFramerate" because the actual frame rate is
+# reported back to the game, ensuring correct timers.
+# If the screen refresh rate cannot be determined,
+# this option is force-disabled
+# (default: disabled)
+#
+# syncToRefreshrate=false
+
+
+# Don't use alpha blending when rendering text
+# (default: disabled)
+#
+# solidFonts=false
+
+
+# Work around buggy graphics drivers which don't
+# properly synchronize texture access, most
+# apparent when text doesn't show up or the map
+# tileset doesn't render at all
+# (default: disabled)
+#
+# subImageFix=false
+
+
+# Enable framebuffer blitting if the driver is
+# capable of it. Some drivers carry buggy
+# implementations of this functionality, so
+# disabling it can be used as a workaround
+# (default: enabled)
+#
+# enableBlitting=true
+
+
+# Limit the maximum size (width, height) of
+# most textures mkxp will create (exceptions are
+# rendering backbuffers and similar).
+# If set to 0, the hardware maximum is used.
+# This is useful for recording traces that can
+# be played back on machines with lower specs.
+# (default: 0)
+#
+# maxTextureSize=0
+
+
+# Set the base path of the game to '/path/to/game'
+# (default: executable directory)
+#
+gameFolder=../../..
+
+
+# Use either right or left Alt + Enter to toggle
+# fullscreen
+# (default: disabled)
+# 
+# anyAltToggleFS=false
+
+
+# Enable F12 game reset
+# (default: enabled)
+#
+# enableReset=true
+
+
+# Allow symlinks for game assets to be followed
+# (default: disabled)
+#
+# allowSymlinks=false
+
+
+# Organisation / company and application / game
+# name to build the directory path where mkxp
+# will store game specific data (eg. key bindings).
+# If not specified, mkxp will save to a common
+# directory shared by all games. Note that these
+# are TWO individual config entries, and both need
+# to be defined for this to take effect.
+# (default: none)
+#
+# dataPathOrg=mycompany
+# dataPathApp=mygame
+
+
+# Set the game window icon to 'path/to/icon.png'
+# (default: none)
+#
+# iconPath=/path/to/icon.png
+
+
+# Instead of playing an RPG Maker game,
+# execute a single plain text script instead
+# (default: none)
+#
+# customScript=/path/to/script.rb
+
+
+# Define raw scripts to be executed before the
+# actual Scripts.rxdata execution starts
+# (default: none)
+#
+# preloadScript=my_win32_wrapper.rb
+# preloadScript=ruby18_fixes.rb
+
+
+# Index all accesible assets via their lower case path
+# (emulates windows case insensitivity)
+# (default: enabled)
+#
+# pathCache=true
+
+
+# Add 'rtp1', 'rtp2.zip' and 'game.rgssad' to the
+# asset search path (multiple allowed)
+# (default: none)
+#
+# RTP=/path/to/rtp1
+# RTP=/path/to/rtp2.zip
+# RTP=/path/to/game.rgssad
+
+
+# Use the script's name as filename in warnings and error messages
+# (default: disabled)
+#
+# useScriptNames=false
+
+
+# Font substitutions allow drop-in replacements of fonts
+# to be used without changing the RGSS scripts,
+# eg. providing 'Open Sans' when the game thinkgs it's
+# using 'Arial'. Font family to be substituted and
+# replacement family are separated by one sole '>'.
+# Be careful not to include any spaces.
+# This is not connected to the built-in font, which is
+# always used when a non-existing font family is
+# requested by RGSS.
+# (default: none)
+#
+# fontSub=Arial>Open Sans
+# fontSub=Times New Roman>Liberation Serif
+
+
+# Because mkxp is usually distributed as a stand alone
+# build, no predefined load paths are initialized
+# ($:, $LOAD_PATH) in the MRI backend. With this option,
+# they can be specified manually (eg. when using a system
+# libruby.so). It is however recommended to statically
+# link all required gems into libruby.so.
+# (default: none)
+#
+# rubyLoadpath=/usr/lib64/ruby/
+# rubyLoadpath=/usr/local/share/ruby/site_ruby
+
+
+# SoundFont to use for midi playback (via fluidsynth)
+# (default: none)
+#
+# midi.soundFont=/usr/share/mysoundfont.sf2
+
+
+# Activate "chorus" effect for midi playback
+#
+# midi.chorus=false
+
+
+# Activate "reverb" effect for midi playback
+#
+# midi.reverb=false
+
+
+# Number of OpenAL sources to allocate for SE playback.
+# If there are a lot of sounds playing at the same time
+# and audibly cutting each other off, try increasing
+# this number. Maximum: 64.
+#
+# SE.sourceCount=6
+
+
+# The Windows game executable name minus ".exe". By default
+# this is "Game", but some developers manually rename it.
+# mkxp needs this name because both the .ini (game
+# configuration) and .rgssad (encrypted data archive) must
+# carry the same name minus their extension, and we cannot
+# guess the executable's name.
+# You could just as well rename them both to "Game.ini" and
+# "Game.rgssad", but specifying the executable name here
+# is a tiny bit less intrusive.
+#
+# execName=Game
+
+
+# Give a hint on which language the game title as
+# specified in the Game.ini is, useful if the encoding
+# is being falsely detected. Relevant only if mkxp was
+# built with automatic encoding conversion (INI_ENCODING).
+# (default: none)
+#
+# titleLanguage=japanese


### PR DESCRIPTION
Two scripts I copied from another [project of mine](https://github.com/VaduNightwave/lightpad) to help with completing the macOS bundle.  Note: this is heavily dependent on a tool from CMake known as "BundleUtilities" (but trust me, it's worth it to use this, instead of trying to do it all by hand).  Essentially, this is to be run after building the app.

```
qmake
make
cmake -P patches/macos/CompleteBundle.cmake <--
```