### PR TITLE
Set debug variables from argv

### DIFF
--- a/binding-mri/binding-mri.cpp
+++ b/binding-mri/binding-mri.cpp
@@ -147,7 +147,16 @@ static void mriBindingInit()
 	_rb_define_module_function(mod, "raw_key_states", mkxpRawKeyStates);
 	_rb_define_module_function(mod, "mouse_in_window", mkxpMouseInWindow);
 
+	/* Load global constants */
 	rb_gv_set("MKXP", Qtrue);
+
+	VALUE debug = rb_bool_new(shState->config().editor.debug);
+	if (rgssVer == 1)
+		rb_gv_set("DEBUG", debug);
+	else if (rgssVer >= 2)
+		rb_gv_set("TEST", debug);
+
+	rb_gv_set("BTEST", rb_bool_new(shState->config().editor.battleTest));
 }
 
 static void

--- a/binding-mruby/binding-mruby.cpp
+++ b/binding-mruby/binding-mruby.cpp
@@ -114,7 +114,16 @@ static void mrbBindingInit(mrb_state *mrb)
 	/* Load RPG module */
 	mrb_load_irep(mrb, mrbModuleRPG);
 
+	/* Load global constants */
 	mrb_define_global_const(mrb, "MKXP", mrb_true_value());
+
+	mrb_value debug = rb_bool_new(shState->config().editor.debug);
+	if (rgssVer == 1)
+		mrb_define_global_const(mrb, "DEBUG", debug);
+	else if (rgssVer >= 2)
+		mrb_define_global_const(mrb, "TEST", debug);
+
+	mrb_define_global_const(mrb, "BTEST", mrb_bool_value(shState->config().editor.battleTest));
 
 	mrb_gc_arena_restore(mrb, arena);
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -189,6 +189,27 @@ void Config::read(int argc, char *argv[])
 // Not gonna take your shit boost
 #define GUARD_ALL( exp ) try { exp } catch(...) {}
 
+	editor.debug = false;
+	editor.battleTest = false;
+
+	/* Read arguments sent from the editor */
+	if (argc > 1)
+	{
+		std::string argv1 = argv[1];
+		/* RGSS1 uses "debug", 2 and 3 use "test" */
+		if (argv1 == "debug" || argv1 == "test")
+			editor.debug = true;
+		else if (argv1 == "btest")
+			editor.battleTest = true;
+
+		/* Fix offset */
+		if (editor.debug || editor.battleTest)
+		{
+			argc--;
+			argv++;
+		}
+	}
+
 #define PO_DESC(key, type, def) (#key, po::value< type >()->default_value(def))
 
 	po::options_description podesc;

--- a/src/config.h
+++ b/src/config.h
@@ -88,6 +88,12 @@ struct Config
 
 	std::vector<std::string> rubyLoadpaths;
 
+	/* Editor flags */
+	struct {
+		bool debug;
+		bool battleTest;
+	} editor;
+
 	/* Game INI contents */
 	struct {
 		std::string scripts;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -508,7 +508,7 @@ findFontsFolderCB(void *data, const char *, const char *fname)
 	char buffer[512];
 	const char *s = fname;
 
-	while (s && i < sizeof(buffer))
+	while (*s && i < sizeof(buffer))
 		buffer[i++] = tolower(*s++);
 
 	buffer[i] = '\0';


### PR DESCRIPTION
Propietary RGSS editors call Game.exe with debug, test or btest arguments (according to issue #190), setting $DEBUG, $TEST or $BTEST respectively as true.

To use it replace Game.exe with the mkxp binary.
Then when using some propietary editor from wine, mkxp will be called instead of a propietary implementation and named flags are included.