### PR TITLE
Case-insensitive ini file parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(MAIN_HEADERS
 	src/flashable.h
 	src/font.h
 	src/input.h
+	src/iniconfig.h
 	src/plane.h
 	src/scene.h
 	src/sprite.h
@@ -167,6 +168,7 @@ set(MAIN_SOURCE
 	src/filesystem.cpp
 	src/font.cpp
 	src/input.cpp
+	src/iniconfig.cpp
 	src/plane.cpp
 	src/scene.cpp
 	src/sprite.cpp

--- a/mkxp.pro
+++ b/mkxp.pro
@@ -89,6 +89,7 @@ HEADERS += \
 	src/flashable.h \
 	src/font.h \
 	src/input.h \
+	src/iniconfig.h \
 	src/plane.h \
 	src/scene.h \
 	src/sprite.h \
@@ -145,6 +146,7 @@ SOURCES += \
 	src/filesystem.cpp \
 	src/font.cpp \
 	src/input.cpp \
+	src/iniconfig.cpp \
 	src/plane.cpp \
 	src/scene.cpp \
 	src/sprite.cpp \

--- a/src/iniconfig.cpp
+++ b/src/iniconfig.cpp
@@ -1,0 +1,114 @@
+#include "iniconfig.h"
+
+#include <algorithm>
+
+std::string toLowerCase(const std::string& str)
+{
+	std::string lower = str;
+	std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+	return lower;
+}
+ 
+std::string trim(const std::string& str, const std::string& chars = "\t\n\v\f\r ")
+{
+	std::string trimmed = str;
+	trimmed.erase(trimmed.find_last_not_of(chars) + 1);
+	trimmed.erase(0, trimmed.find_first_not_of(chars));
+	return trimmed;
+}
+
+INIConfiguration::Section::Section (const std::string& sname) : m_Name (sname), m_PropertyMap()
+{
+}
+
+bool INIConfiguration::Section::getStringProperty (const std::string& name, std::string& outPropStr) const
+{
+	try
+	{
+		outPropStr = m_PropertyMap.at(toLowerCase(name)).m_Value;
+		return true;
+	}
+	catch (std::out_of_range& oorexcept)
+	{
+		return false;
+	}
+}
+
+bool INIConfiguration::load (std::istream& is)
+{
+	if (!is.good())
+	{
+		return false;
+	}
+
+	std::string currSectionName;
+
+	std::string line;
+	std::getline (is, line);
+
+	while (!is.eof() && !is.bad())
+	{
+		if (line[0] == '[')
+		{
+			currSectionName = line.substr (1, line.find_last_of (']') - 1);
+		}
+		else if (line[0] != '#' && line.length() > 2)
+		{
+			int crloc = line.length() - 1;
+
+			if (crloc >= 0  && line[crloc] == '\r') //check for Windows-style newline
+				line.resize (crloc);                //and correct
+
+			size_t equalsPos = line.find_first_of ("=");
+
+			if (equalsPos != std::string::npos)
+			{
+				std::string key = line.substr (0, equalsPos);
+				std::string val = line.substr (equalsPos + 1);
+
+				addProperty (currSectionName, key , val);
+			}
+		}
+
+		std::getline (is, line);
+	}
+
+	if (is.bad())
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+std::string INIConfiguration::getStringProperty(const std::string& sname, const std::string& name, const std::string& def) const
+{
+	auto sectionIt = m_SectionMap.find(toLowerCase(sname));
+
+	if (sectionIt != m_SectionMap.end())
+	{
+		std::string prop;
+
+		if(sectionIt->second.getStringProperty(name, prop))
+		{
+			return prop;
+		}
+	}
+	
+	return def;
+}
+
+void INIConfiguration::addProperty (const std::string& sname, const std::string& name, const std::string& val)
+{
+	if (m_SectionMap.find (toLowerCase(sname)) == m_SectionMap.end())
+	{
+		m_SectionMap.emplace (toLowerCase(sname), Section (sname));
+	}
+
+	Section::Property p;
+	p.m_Name = trim(name);
+	p.m_Value = trim(val);
+
+	m_SectionMap.at (toLowerCase(sname)).m_PropertyMap[toLowerCase(p.m_Name)] = p;
+}

--- a/src/iniconfig.h
+++ b/src/iniconfig.h
@@ -1,0 +1,46 @@
+#ifndef INICONFIG_H
+#define INICONFIG_H
+
+#include <iostream>
+#include <map>
+
+class INIConfiguration
+{
+	class Section
+	{
+		friend class INIConfiguration;
+
+		struct Property
+		{
+			std::string m_Name;
+			std::string m_Value;
+		};
+
+		typedef std::map<std::string, Property> property_map;
+	public:
+		Section (const Section& s) = default;
+		Section (Section&& s) = default;
+
+		bool getStringProperty (const std::string& name, std::string& outPropStr) const;
+
+	private:
+		explicit Section (const std::string& name);
+
+		std::string m_Name;
+		property_map m_PropertyMap;
+	};
+
+	typedef std::map<std::string, Section> section_map;
+public:
+	bool load (std::istream& inStream);
+
+	std::string getStringProperty(const std::string& sname, const std::string& name, const std::string& def = "") const;
+
+protected:
+	void addProperty (const std::string& sname, const std::string& name, const std::string& val);
+
+private:
+	section_map m_SectionMap;
+};
+
+#endif // INICONFIG_H


### PR DESCRIPTION
On Windows, RPG Maker has no issue reading Game.ini files with case insensitive key or section names (i.e. 'game' instead of the more common 'Game' section). On the other hand, MKXP fails to start with a "No game scripts specified (missing Game.ini)" error message when the section or key name is not exactly as expected.

This PR fixes this by using a case insensitive ini parser. This parser uses Boost.Optional, Boost.Algorithm and Boost.Lexical_Cast.

Only tested on Linux with CMake.