### PR TITLE
Fix font enumeration

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -469,7 +469,7 @@ fontSetEnumCB (void *data, const char *dir, const char *fname)
 	const char *ext = findExt(fname);
 
 	if (!ext)
-		return PHYSFS_ENUM_STOP;
+		return PHYSFS_ENUM_OK;
 
 	char lowExt[8];
 	size_t i;
@@ -479,7 +479,7 @@ fontSetEnumCB (void *data, const char *dir, const char *fname)
 	lowExt[i] = '\0';
 
 	if (strcmp(lowExt, "ttf") && strcmp(lowExt, "otf"))
-		return PHYSFS_ENUM_STOP;
+		return PHYSFS_ENUM_OK;
 
 	char filename[512];
 	snprintf(filename, sizeof(filename), "%s/%s", dir, fname);


### PR DESCRIPTION
Currently, the font enumeration callback erroneously stops searching if
it finds any files that aren't fonts. In the case that you have, say, a
desktop.ini or a .DS_Store or a license file, it may prevent all of the
fonts from being loaded. This commit resolves this.