### PR TITLE
Fix: undefined-var-template

### DIFF
--- a/src/vertex.h
+++ b/src/vertex.h
@@ -66,4 +66,6 @@ struct VertexTraits
 	static const GLsizei attrCount;
 };
 
+template <class VertType> const VertexAttribute* VertexTraits<VertType>::attr;
+
 #endif // VERTEX_H


### PR DESCRIPTION
I encountered this problem when I tried to build mkxp.

```
make: *** [filesystem.o] Error 1
In file included from src/bitmap.cpp:33:
src/gl-meta.h:57:44: warning: instantiation of variable 'VertexTraits<Vertex>::attr' required here, but no definition is available [-Wundefined-var-template]
        vao.attr      = VertexTraits<VertexType>::attr;
                                                  ^
src/quad.h:79:11: note: in instantiation of function template specialization 'GLMeta::vaoFillInVertexData<Vertex>' requested here
                GLMeta::vaoFillInVertexData<Vertex>(vao);
                        ^
src/vertex.h:65:32: note: forward declaration of template entity is here
        static const VertexAttribute *attr;
                                      ^
src/gl-meta.h:57:44: note: add an explicit instantiation declaration to suppress this warning if 'VertexTraits<Vertex>::attr' is explicitly instantiated in another translation unit
        vao.attr      = VertexTraits<VertexType>::attr;
                                                  ^
```
<img width="1270" alt="2018-11-15 8 02 55" src="https://user-images.githubusercontent.com/4011729/48552120-8ed7f180-e912-11e8-9b7b-d85c975fb4a3.png">

Not sure why, but I managed to fix it by adding a line to define `VertexTraits<Vertex>::attr`, and it worked for me.

### Environment
- OSX 10.12.5
- ruby 2.2 or 2.5