### PR TITLE
Ensure ALStream source is not null in ALStream::queryOffset()

### DIFF
--- a/src/alstream.cpp
+++ b/src/alstream.cpp
@@ -186,7 +186,7 @@ ALStream::State ALStream::queryState()
 
 float ALStream::queryOffset()
 {
-	if (state == Closed)
+	if (state == Closed || !source)
 		return 0;
 
 	float procOffset = static_cast<float>(procFrames) / source->sampleRate();


### PR DESCRIPTION
Just check that `ALStream::source` is not null before calling `source->sampleRate()`.