### PR TITLE
Add .editorconfig to the project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root=true
+[*]
+end_of_line = lf
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Usually C/C++ projects use spaces, so this should override people's space settings assuming they have editorconfig compatible editor or plugin installed.