### PR TITLE
Rational errors fix

### DIFF
--- a/binding-mri/binding-util.h
+++ b/binding-mri/binding-util.h
@@ -228,7 +228,7 @@ rb_float_arg(VALUE arg, double *out, int argPos = 0)
 		break;
 
 	default:
-		rb_raise(rb_eTypeError, "Argument %d: Expected float", argPos);
+		rb_raise(rb_eTypeError, "Argument %d: Expected float(got 0x%x)", argPos, rb_type(arg));
 	}
 }
 
@@ -243,11 +243,12 @@ rb_int_arg(VALUE arg, int *out, int argPos = 0)
 		break;
 
 	case RUBY_T_FIXNUM :
+	case RUBY_T_RATIONAL :
 		*out = FIX2INT(arg);
 		break;
 
 	default:
-		rb_raise(rb_eTypeError, "Argument %d: Expected fixnum", argPos);
+		rb_raise(rb_eTypeError, "Argument %d: Expected fixnum(got 0x%x)", argPos, rb_type(arg));
 	}
 }
 


### PR DESCRIPTION
- Better debug information on float errors (lines 231 and 251).
- line 246 fixes ruby rational errors