### PR TITLE
Unlock resolution

### DIFF
--- a/binding-mri/graphics-binding.cpp
+++ b/binding-mri/graphics-binding.cpp
@@ -222,8 +222,8 @@ void graphicsBindingInit()
 	INIT_GRA_PROP_BIND( FrameRate,  "frame_rate"  );
 	INIT_GRA_PROP_BIND( FrameCount, "frame_count" );
 
-	if (rgssVer >= 2)
-	{
+	//if (rgssVer >= 2)
+	//{
 	_rb_define_module_function(module, "width", graphicsWidth);
 	_rb_define_module_function(module, "height", graphicsHeight);
 	_rb_define_module_function(module, "wait", graphicsWait);
@@ -233,7 +233,7 @@ void graphicsBindingInit()
 	_rb_define_module_function(module, "resize_screen", graphicsResizeScreen);
 
 	INIT_GRA_PROP_BIND( Brightness, "brightness" );
-	}
+	//}
 
 	if (rgssVer >= 3)
 	{

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -291,10 +291,10 @@ static std::string baseName(const std::string &path)
 static void setupScreenSize(Config &conf)
 {
 	if (conf.defScreenW <= 0)
-		conf.defScreenW = (conf.rgssVersion == 1 ? 640 : 544);
+		conf.defScreenW = 2048;
 
 	if (conf.defScreenH <= 0)
-		conf.defScreenH = (conf.rgssVersion == 1 ? 480 : 416);
+		conf.defScreenH = 1536;
 }
 
 void Config::readGameINI()

--- a/src/glstate.cpp
+++ b/src/glstate.cpp
@@ -120,7 +120,7 @@ GLState::GLState(const Config &conf)
 	blendMode.init(BlendNormal);
 	blend.init(true);
 	scissorTest.init(false);
-	scissorBox.init(IntRect(0, 0, 640, 480));
+	scissorBox.init(IntRect(0, 0, conf.defScreenW, conf.defScreenH));
 	program.init(0);
 
 	if (conf.maxTextureSize > 0)

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -926,8 +926,8 @@ int Graphics::height() const
 
 void Graphics::resizeScreen(int width, int height)
 {
-	width = clamp(width, 1, 640);
-	height = clamp(height, 1, 480);
+	width = clamp(width, 1, p->threadData->config.defScreenW);
+	height = clamp(height, 1, p->threadData->config.defScreenH);
 
 	Vec2i size(width, height);
 


### PR DESCRIPTION
Modification to unlock window size & resolution.

Automatically determines the game's resolution.
If it is lower than 800/600 it upscale's it to 800/600 (can be changed in lines 129 & 130 of eventhread.cpp)
and if the game uses a higher resolution auto-adjusts the window.

note: on linux (at least on my machine) it cannot auto-adjust the initial window, if the default allowed resolution is equal or higher
of the monitor resolution (the initial window size will be equal to the monitor resolution).
Probably a bug of my linux drivers.
Since I am not sure why it happens (linux drivers?/ SDL bug?/XFCE bug?), the workaround was to set the
defScreenW and defScreenH in "mkxp.conf" to a smaller value than the monitor resolution.
e.g. On a monitor 1920/1080 can be set to
defScreenW=1910
defScreenH=1070
and then works correctly.