### PR TITLE
Allow setting the initial value of Graphics.show_cursor from mkxp.conf

### DIFF
--- a/mkxp.conf.sample
+++ b/mkxp.conf.sample
@@ -48,6 +48,12 @@
 # fullscreen=false
 
 
+# Enable/disable cursor (mouse)
+# (default: disabled)
+#
+# showCursor=false
+
+
 # Preserve game screen aspect ratio,
 # as opposed to stretch-to-fill
 # (default: enabled)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -158,6 +158,7 @@ void Config::read(int argc, char *argv[])
 	PO_DESC(winResizable, bool, false) \
 	PO_DESC(fullscreen, bool, false) \
 	PO_DESC(fixedAspectRatio, bool, true) \
+	PO_DESC(showCursor, bool, false) \
 	PO_DESC(smoothScaling, bool, true) \
 	PO_DESC(vsync, bool, false) \
 	PO_DESC(defScreenW, int, 0) \

--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,7 @@ struct Config
 
 	bool winResizable;
 	bool fullscreen;
+	bool showCursor;
 	bool fixedAspectRatio;
 	bool smoothScaling;
 	bool vsync;

--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -105,6 +105,8 @@ EventThread::EventThread()
       showCursor(false)
 {}
 
+SDL_DisplayMode dm = {0};
+
 void EventThread::process(RGSSThreadData &rtData)
 {
 	SDL_Event event;
@@ -119,6 +121,8 @@ void EventThread::process(RGSSThreadData &rtData)
 #endif
 
 	fullscreen = rtData.config.fullscreen;
+	showCursor = rtData.config.showCursor;
+	SDL_GetDesktopDisplayMode(0, &dm);
 	int toggleFSMod = rtData.config.anyAltToggleFS ? KMOD_ALT : KMOD_LALT;
 
 	fps.lastFrame = SDL_GetPerformanceCounter();
@@ -540,6 +544,7 @@ void EventThread::resetInputStates()
 
 void EventThread::setFullscreen(SDL_Window *win, bool mode)
 {
+	SDL_GetDesktopDisplayMode(0, &dm);
 	SDL_SetWindowFullscreen
 	        (win, mode ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 	fullscreen = mode;


### PR DESCRIPTION
Enables mouse support for games that use Shaz's Super Simple Mouse System.
- needs Ancurio's win32api wrapper preloaded https://github.com/Ancurio/mkxp/issues/73
- I tested it only with Super simple mouse script. Probably won't work with other scripts that heavily rely on WIN32API's.