### PR TITLE
Removed code that prevent mkxp from running when sound engine can't initialize

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,7 @@ int rgssThreadFun(void *userdata)
 
 	/* Setup AL context */
 	ALCcontext *alcCtx = alcCreateContext(threadData->alcDev, 0);
-
+/** Not necessary, because may run on device without sound
 	if (!alcCtx)
 	{
 		rgssThreadError(threadData, "Error creating OpenAL context");
@@ -126,7 +126,7 @@ int rgssThreadFun(void *userdata)
 
 		return 0;
 	}
-
+*/
 	alcMakeContextCurrent(alcCtx);
 
 	try
@@ -295,6 +295,7 @@ int main(int argc, char *argv[])
 
 	ALCdevice *alcDev = alcOpenDevice(0);
 
+/** Not necessary, may run on device with no sound device
 	if (!alcDev)
 	{
 		showInitError("Error opening OpenAL device");
@@ -305,7 +306,7 @@ int main(int argc, char *argv[])
 
 		return 0;
 	}
-
+*/
 	SDL_DisplayMode mode;
 	SDL_GetDisplayMode(0, 0, &mode);
 


### PR DESCRIPTION
Hi Ancurio,

First of all thanks for this amazing work you did!

When there is no sound card detected or configured on the system, it should still be OK to run games (I have had to do that to run MXKP on a Raspberry PI emulated with QEMU, as emulation does not handle the sound card).  So I removed the blocking tests, and the games still seem to run fine.

Maybe we should throw a non-critical alert message when the engine fails to initialize its sound system? In that case, do not hesitate to add code for that.

Cheers!

Mathieu